### PR TITLE
Add custom event "handleurl"

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,7 @@ var secondWebView = WK.createWebView({
 webView.addEventListener('handleurlscheme', function(e) {
     // Check for e.url
 });
+```
 
 Author
 ---------------

--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ var secondWebView = WK.createWebView({
 #### Custom event "handleurlscheme"
 - the custom url scheme has to be registered in the properties allowedURLSchemes array.
 - Passes the e.url for a custom url scheme
-- Introduced custom event because iOS10+ causes issues for some customurlschemes and forwarding the url via a titanium event to handle via the Titanium app is simpler short term solution than implementing "WKURLSchemeHandler" which is iOS11+ only.
+- Introduced "handleurlscheme" custom event because iOS10+ causes issues for some customurlschemes and forwarding the url via a titanium event to handle via the Titanium app is a simpler short term solution than implementing "WKURLSchemeHandler" which is iOS11+ only.
 
 ```js
 // Add an event listener to listen for handleurlscheme

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Features
 | load | url, title |
 | redirect | url, title |
 | error | url, title, error |
+| handleurlscheme | url |
 
 #### Constants
 
@@ -262,6 +263,17 @@ var secondWebView = WK.createWebView({
     configuration: config2
 });
 ```
+
+#### Custom event "handleurlscheme"
+- the custom url scheme has to be registered in the properties allowedURLSchemes array.
+- Passes the e.url for a custom url scheme
+- Introduced custom event because iOS10+ causes issues for some customurlschemes and forwarding the url via a titanium event to handle via the Titanium app is simpler short term solution than implementing "WKURLSchemeHandler" which is iOS11+ only.
+
+```js
+// Add an event listener to listen for handleurlscheme
+webView.addEventListener('handleurlscheme', function(e) {
+    // Check for e.url
+});
 
 Author
 ---------------

--- a/README.md
+++ b/README.md
@@ -1,18 +1,15 @@
 # Ti.WKWebView 
 [![Build Status](https://travis-ci.org/appcelerator-modules/Ti.WKWebView.svg?branch=master)](https://travis-ci.org/appcelerator-modules/Ti.WKWebView) [![License](http://hans-knoechel.de/shields/shield-license.svg?v=2)](./LICENSE)  [![Support](http://hans-knoechel.de/shields/shield-slack.svg?v=3)](http://tislack.org)
 
-Summary
----------------
+## Summary
 Ti.WKWebView is an open source project to support the `WKWebView` API with Titanium.
 
-Requirements
----------------
-- Titanium Mobile SDK 5.0.0.GA or later
-- iOS 9 or later
-- Xcode 7.0 or later
+## Requirements
+- Titanium SDK 5.0.0.GA or later
+- iOS 9+
+- Xcode 7+
 
-Download + Setup
----------------
+## Download + Setup
 
 ### Download
 * [Stable release](https://github.com/appcelerator-modules/ti.wkwebview/releases)
@@ -30,8 +27,8 @@ Edit the iOS and modules section of your `tiapp.xml` file to include this module
 </modules>
 ```
 
-Features
----------------
+## Features
+
 ### API's
 
 | Name | Example|
@@ -101,7 +98,7 @@ Features
 | load | url, title |
 | redirect | url, title |
 | error | url, title, error |
-| handleurlscheme | url |
+| handleurl | url |
 
 #### Constants
 
@@ -264,26 +261,24 @@ var secondWebView = WK.createWebView({
 });
 ```
 
-#### Custom event "handleurlscheme"
-- the custom url scheme has to be registered in the properties allowedURLSchemes array.
-- Passes the e.url for a custom url scheme
-- Introduced "handleurlscheme" custom event because iOS10+ causes issues for some customurlschemes and forwarding the url via a titanium event to handle via the Titanium app is a simpler short term solution than implementing "WKURLSchemeHandler" which is iOS11+ only.
+### Custom event "handleurl"
+- The custom url-scheme has to be registered in the `allowedURLSchemes` array-property
+- Passes the `url` for a custom url-scheme
+- The event is introduced because iOS 10+ causes issues for some custom url-schemes and forwarding the url 
+  in an event is a simpler short term solution than implementing the `WKURLSchemeHandler` which is iOS 11+ only.
 
 ```js
-// Add an event listener to listen for handleurlscheme
-webView.addEventListener('handleurlscheme', function(e) {
+// Add an event listener to listen for a custom URL-scheme
+webView.addEventListener('handleurl', function(e) {
     // Check for e.url
 });
 ```
 
-Author
----------------
-Hans Knoechel ([@hansemannnn](https://twitter.com/hansemannnn) / [Web](http://hans-knoechel.de)) for Appcelerator
+## Author
+Hans Knoechel ([@hansemannnn](https://twitter.com/hansemannnn) / [Web](http://hans-knoechel.de)) for Axway Appcelerator
 
-License
----------------
+## License
 Apache 2.0
 
-Contributing
----------------
+## Contributing
 Code contributions are greatly appreciated, please submit a new [pull request](https://github.com/appcelerator-modules/ti.wkwebview/pull/new/master)!

--- a/ios/Classes/TiWkwebviewWebView.m
+++ b/ios/Classes/TiWkwebviewWebView.m
@@ -570,9 +570,11 @@ extern NSString * const kTiWKEventCallback;
 {
     if ([[[self proxy] valueForKey:@"allowedURLSchemes"] containsObject:navigationAction.request.URL.scheme]) {
         if ([[UIApplication sharedApplication] canOpenURL:navigationAction.request.URL]) {
-            // custom fireevent "handleurlscheme" to give url to Titanium app to handle implementation
-            if ([[self proxy] _hasListeners:@"handleurlscheme"]) {
-                [[self proxy] fireEvent:@"handleurlscheme" withObject:@{@"url": [TiUtils stringValue:navigationAction.request.URL]}];
+            // Event to return url to Titanium in order to handle OAuth and more
+            if ([[self proxy] _hasListeners:@"handleurl"]) {
+                [[self proxy] fireEvent:@"handleurl" withObject:@{
+                    @"url": [TiUtils stringValue:[[navigationAction request] URL]]
+                }];
             }
 
             [[UIApplication sharedApplication] openURL:navigationAction.request.URL];

--- a/ios/Classes/TiWkwebviewWebView.m
+++ b/ios/Classes/TiWkwebviewWebView.m
@@ -570,6 +570,11 @@ extern NSString * const kTiWKEventCallback;
 {
     if ([[[self proxy] valueForKey:@"allowedURLSchemes"] containsObject:navigationAction.request.URL.scheme]) {
         if ([[UIApplication sharedApplication] canOpenURL:navigationAction.request.URL]) {
+            // custom fireevent "handleurlscheme" to give url to Titanium app to handle implementation
+            if ([[self proxy] _hasListeners:@"handleurlscheme"]) {
+                [[self proxy] fireEvent:@"handleurlscheme" withObject:@{@"url": [TiUtils stringValue:navigationAction.request.URL]}];
+            }
+
             [[UIApplication sharedApplication] openURL:navigationAction.request.URL];
             decisionHandler(WKNavigationActionPolicyCancel);
             return;

--- a/ios/manifest
+++ b/ios/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 2.4.3
+version: 2.5.0
 apiversion: 2
 architectures: armv7 arm64 i386 x86_64
 description: ti.wkwebview

--- a/ios/manifest
+++ b/ios/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 2.4.2
+version: 2.4.3
 apiversion: 2
 architectures: armv7 arm64 i386 x86_64
 description: ti.wkwebview


### PR DESCRIPTION
Added fireevent "handleurlscheme" event to give Titanium app option to handle the url for customURLschemes.

iOS 10+ seems to have changed how custom url schemes are handled causing errors for Browser based Single Sign On (SSO) solutions handled view webview. StackOverflow solutions seem to indicate we have to implement WKURLSchemeHandler (iOS11+) natively. 

However interim solution is to pass the url back to Titanium to handle via a simple firevent solution.

Some background:
https://medium.com/glose-team/custom-scheme-handling-and-wkwebview-in-ios-11-72bc5113e344