### PR TITLE
Fix link clicks for links with target="_blank"

### DIFF
--- a/ios/Classes/TiWkwebviewWebView.m
+++ b/ios/Classes/TiWkwebviewWebView.m
@@ -871,6 +871,17 @@ static NSString *const baseInjectScript = @"Ti._hexish=function(a){var r='';var 
   decisionHandler(WKNavigationResponsePolicyAllow);
 }
 
+- (WKWebView *)webView:(WKWebView *)webView createWebViewWithConfiguration:(WKWebViewConfiguration *)configuration forNavigationAction:(WKNavigationAction *)navigationAction windowFeatures:(WKWindowFeatures *)windowFeatures
+{
+    
+    if (!navigationAction.targetFrame.isMainFrame) {
+        
+        [webView loadRequest:navigationAction.request];
+    }
+    
+    return nil;
+}
+
 #pragma mark Internal Utilities
 
 static NSString *UIKitLocalizedString(NSString *string)


### PR DESCRIPTION
Currently, when a link in  a page has a target=_blank parameter, the webview doesn't respond and doesn't load the page. Nothing happens.

Added this fix so it will load the page properly.